### PR TITLE
Handle new map format, some style cleanup, remove some unused code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+chunks/*.json.gz

--- a/README
+++ b/README
@@ -4,7 +4,7 @@ other demo video: http://vimeo.com/16156993
 Interesting but completely unrelated music video: http://www.youtube.com/watch?v=tVoH6ZTDrD0&feature=related
 
 Requires: Apache configuration, PHP with zlib (php5-zlib), WebGL-enabled browser,
-save tree in [wwwroot]/world/ , writable world/ tree (chmod -R 777 world)
+save tree in [wwwroot]/world/ , writable chunks/ dir (chmod -R 777 chunks)
 
 http://www.php.net/manual/en/zlib.installation.php
 

--- a/buildindex.php
+++ b/buildindex.php
@@ -1,87 +1,67 @@
 <?php
+
+// I don't know what this file is for. -endenizen
+
 ini_set('memory_limit', '128M');
-  require_once('readchunk.php');
+require_once('readchunk.php');
 
-  function trimpath($p) {
-    $pos = strpos($p, 'world/');
-    return substr($p, $pos+6);
-  }
+function trimpath($p) {
+  $pos = strpos($p, 'world/');
+  return substr($p, $pos+6);
+}
 
-  function process_dir($dir,$recursive = FALSE) {
-    if (is_dir($dir)) {
-      for ($list = array(),$handle = opendir($dir); (FALSE !== ($file = readdir($handle)));) {
-        if (($file != '.' && $file != '..' && $file != 'level.dat.json' && $file != 'level.dat.json.gz') && (file_exists($path = $dir.'/'.$file))) {
-          if (is_dir($path) && ($recursive)) {
-            $list = array_merge($list, process_dir($path, TRUE));
+function process_dir($dir,$recursive = FALSE) {
+  if (is_dir($dir)) {
+    for ($list = array(),$handle = opendir($dir); (FALSE !== ($file = readdir($handle)));) {
+      if (($file != '.' && $file != '..' && $file != 'level.dat.json' && $file != 'level.dat.json.gz') && (file_exists($path = $dir.'/'.$file))) {
+        if (is_dir($path) && ($recursive)) {
+          $list = array_merge($list, process_dir($path, TRUE));
+        } else {
+          $entry = array('filename' => $file);
+          
+          do if (!is_dir($path)) {
+            $pos = strpos($path, '.b6z');
+            $pos2 = strpos($path, '.gz');
+            if ($pos >0 | $pos2>0) {
+              unlink($path);
+              continue;
+            } 
+
+            $pos3 = strpos($file, 'evel.dat');
+            if ($pos3>0) continue;
+
+            // Won't work with new maps
+            // $entry['dat'] = readchunk($path);
+            $entry['filename'] = trimpath($path);
+ 
+            break;
           } else {
-            
-            $entry = array('filename' => $file);
-            
- //---------------------------------------------------------//
- //                     - SECTION 1 -                       //
- //          Actions to be performed on ALL ITEMS           //
- //-----------------    Begin Editable    ------------------//
+            break;
+          } while (FALSE);
 
-  //$entry['modtime'] = filemtime($path);
-
- //-----------------     End Editable     ------------------//
-            do if (!is_dir($path)) {
- //---------------------------------------------------------//
- //                     - SECTION 2 -                       //
- //         Actions to be performed on FILES ONLY           //
- //-----------------    Begin Editable    ------------------//
-
-  //$entry['size'] = filesize($path);
-  
-  $pos = strpos($path, '.b6z');
-  $pos2 = strpos($path, '.gz');
-  if ($pos >0 | $pos2>0) {
-    unlink($path);
-    continue;
-  } 
-  
-  $pos3 = strpos($file, 'evel.dat');
-  if ($pos3>0) continue;
-
-  $entry['dat'] = readchunk($path);
-     
-  $entry['filename'] = trimpath($path);
-   
- //-----------------     End Editable     ------------------//
-              break;
-            } else {
- //---------------------------------------------------------//
- //                     - SECTION 3 -                       //
- //       Actions to be performed on DIRECTORIES ONLY       //
- //-----------------    Begin Editable    ------------------//
-
- //-----------------     End Editable     ------------------//
-              break;
-            } while (FALSE);
-            //if ($entry['dat'] & $entry['dat']['xpos'] )
-              $list[] = $entry;
-          }
+          $list[] = $entry;
         }
       }
-      closedir($handle);
-      return $list;
-    } else return FALSE;
-  }
+    }
+    closedir($handle);
+    return $list;
+  } else return FALSE;
+}
  
-  $wf = $_SERVER['SCRIPT_FILENAME'];
-  $pos = strrpos($wf, '/');
-  $wd = substr($wf, 0, $pos);  
+$wf = $_SERVER['SCRIPT_FILENAME'];
+$pos = strrpos($wf, '/');
+$wd = substr($wf, 0, $pos);  
 
-  if (file_exists($wd.'/chunks.json')) {
-    $result = file_get_contents($wd.'/chunks.json');
-  } else {
-    $result = json_encode(process_dir($wd . '/world', TRUE));
-    
-    file_put_contents($wd.'/chunks.json', $result);
-  }
-  header('Cache-Control: no-cache, must-revalidate');
-  header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-  header('Content-type: application/json');  
-  echo $result; 
+if (file_exists($wd.'/chunks.json')) {
+  $result = file_get_contents($wd.'/chunks.json');
+} else {
+  $result = json_encode(process_dir($wd . '/world', TRUE));
+  file_put_contents($wd.'/chunks.json', $result);
+}
+
+header('Cache-Control: no-cache, must-revalidate');
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Content-type: application/json');  
+echo $result; 
 
 ?>

--- a/getchunk.php
+++ b/getchunk.php
@@ -3,10 +3,5 @@
 
   header("Content-Encoding: gzip");
 
-  $wf = $_SERVER['SCRIPT_FILENAME'];
-  $pos = strrpos($wf, '/');
-  $wd = substr($wf, 0, $pos);
-
-  jsonchunkout($wd . '/world' .$_GET['file']);
-   
+  jsonChunkOut($_GET['posx'], $_GET['posz']);
 ?>

--- a/getlevel.php
+++ b/getlevel.php
@@ -10,6 +10,6 @@ $levelfile = $wd.'/world/level.dat';
 
 header("Content-Encoding: gzip");
 
-jsonchunkout($levelfile);
+jsonFileOut($levelfile);
 
 ?>

--- a/main.js
+++ b/main.js
@@ -33,6 +33,3 @@ window.onload = function() {
 };
 
 main();
-
-//window.setTimeout('init()', 20);
-

--- a/readchunk.php
+++ b/readchunk.php
@@ -1,55 +1,49 @@
 <?php
 ini_set('display_errors', true);
 
-/* return the value of the most significant bit */
-function get_ms1bit(/*int*/ $i)
-{
-    $x = 0;
-    for ($j = $i; $i && !($j == 1); $j >>= 1) { $x++; }
-    return $i ? $j <<= $x: 0;
-}
+$wf = $_SERVER['SCRIPT_FILENAME'];
+$pos = strrpos($wf, '/');
+$wd = substr($wf, 0, $pos);
 
-function readint($str, $name) {
-  $pos = strpos($str, $name);
+$CHUNK_DIR = $wd . '/chunks/';
+$REGION_DIR = $wd . '/world/region/';
 
-  if ($pos === false) return -9999;
+function readChunk($posx, $posz) {
+  global $REGION_DIR;
+  // calculate region file to read
+  $regionX = floor($posx / 32);
+  $regionZ = floor($posz / 32);
 
-  $datx = substr($str, $pos+4, 4);
-
-  $dat = unpack('C*', $datx);
-  
-  if (get_ms1bit($dat[4]) == 128) 
-    $isnegative = true;
-  else
-    $isnegative = false;
-  
-  $Number = ($dat[1]<<24) | ($dat[2]<<16) | ($dat[3]<<8) | ($dat[4]);
-
-  if ($isnegative) {
-    $Number = -(pow(2, 32) - $Number);
+  // open region file, seek to header info
+  $file = gzopen($REGION_DIR . "r.$regionX.$regionZ.mcr", 'r');
+  $chunkHeaderLoc = 4 * (($posx % 32) + ($posz % 32) * 32);
+  gzseek($file, $chunkHeaderLoc);
+  $info = unpack('C*', gzread($file, 4));
+  $chunkDataLoc = ($info[1]<<16)|($info[2]<<8)|($info[3]);
+  if($chunkDataLoc == 0) {
+    return '';
   }
+  
+  // seek to data, write to gz and return
+  gzseek($file, $chunkDataLoc * 4096);
+  $info = unpack('C*', gzread($file, 4));
+  $chunkLength = ($info[1]<<32)|($info[2]<<16)|($info[3]<<8)|($info[4]);
+  
+  // read to skip over compression byte
+  gzread($file, 1);
 
-  return $Number;
+  // skip first two bytes for deflate
+  gzread($file, 2);
+  // leave off last four bytes for deflate
+  $chunkLength -= 4;
+
+  $contents = gzread($file, $chunkLength - 1);
+  $contents = gzinflate($contents);
+  $data = array_merge(unpack("C*", $contents));
+  return $data;
 }
 
-function readchunk($path) {
-  $zd = gzopen($path, "r");
-  $contents = gzread($zd, 9990000);
-  gzclose($zd);
-
-  $ret = array();
-  $xpos = readint($contents, 'xPos');
-  if ($xpos!=-9999) {
-    $ret['xpos'] = $xpos;
-    $ret['zpos'] = readint($contents,'zPos');
-
-    return $ret;
-  } else {
-    return null;
-  }
-}
-
-function jsonchunkout($path) {
+function jsonFileOut($path) {
   if (file_exists($path.'.json.gz')) {
     echo file_get_contents($path.'.json.gz');
     return true;
@@ -71,11 +65,25 @@ function jsonchunkout($path) {
   }
 }
 
+function jsonChunkOut($posx, $posy) {
+  global $CHUNK_DIR;
+  $chunkFile = $CHUNK_DIR . "c.$posx.$posy.json.gz";
+  if(file_exists($chunkFile)) {
+    echo file_get_contents($chunkFile);
+    return true;
+  } else {
+    $chunkData = readChunk($posx, $posy);
 
-//if ($argv[1]) {
-// echo 'reading chunk ' . $argv[1] . "\r\n";
-// var_dump(readchunk($argv[1])) . "\r\n";
-//}
+    $gz = gzencode(json_encode($chunkData));
 
+    $cf = fopen($chunkFile, 'wb');
+    fwrite($cf, $gz);
+    fclose($cf);
+
+    echo $gz;
+
+    return true;
+  }
+}
 
 ?>

--- a/readchunk.php
+++ b/readchunk.php
@@ -10,6 +10,7 @@ $REGION_DIR = $wd . '/world/region/';
 
 function readChunk($posx, $posz) {
   global $REGION_DIR;
+
   // calculate region file to read
   $regionX = floor($posx / 32);
   $regionZ = floor($posz / 32);
@@ -20,8 +21,10 @@ function readChunk($posx, $posz) {
   gzseek($file, $chunkHeaderLoc);
   $info = unpack('C*', gzread($file, 4));
   $chunkDataLoc = ($info[1]<<16)|($info[2]<<8)|($info[3]);
+
+  // if chunk hasn't been generated, return empty
   if($chunkDataLoc == 0) {
-    return '';
+    return array();
   }
   
   // seek to data, write to gz and return
@@ -65,14 +68,14 @@ function jsonFileOut($path) {
   }
 }
 
-function jsonChunkOut($posx, $posy) {
+function jsonChunkOut($posx, $posz) {
   global $CHUNK_DIR;
-  $chunkFile = $CHUNK_DIR . "c.$posx.$posy.json.gz";
+  $chunkFile = $CHUNK_DIR . "c.$posx.$posz.json.gz";
   if(file_exists($chunkFile)) {
     echo file_get_contents($chunkFile);
     return true;
   } else {
-    $chunkData = readChunk($posx, $posy);
+    $chunkData = readChunk($posx, $posz);
 
     $gz = gzencode(json_encode($chunkData));
 

--- a/viewer.js
+++ b/viewer.js
@@ -3,7 +3,6 @@
 //requires jquery
 //requires world
 
-
 var winx = 50;
 var winy = 55;
 
@@ -16,11 +15,11 @@ function Viewer(url) {
 
     $.newWindow({id:name,posx:winx,posy:winy,width:730,height:500, title:name,content:data, type: typ});
     $.minimizeWindow(name);
-    winx+=15;
-    winy+=20;
+    winx += 15;
+    winy += 20;
   };
 
-  var n=0;
+  var n = 0;
 
   this.chunkLoaded = function(chunk) {    
       //viewer.showLevel('Chunk'+n.toString(), chunk);
@@ -32,23 +31,16 @@ function Viewer(url) {
 
     viewer.world = world;
     viewer.showData('World', prettyPrint(world.level));
-    //viewer.world.loadArea();
   };
 
-
   this.init = function() {
-
     prettyPrint.config.styles['default'].td.color = '#fff';
     prettyPrint.config.styles['default'].td.backgroundColor = 'rgba(15%,15%,20%,0.7)';
     prettyPrint.config.styles['default'].td.border = '1px solid #fff';
     prettyPrint.config.styles['default'].th.border = '1px solid #fff';
     prettyPrint.config.maxDepth = 10;
 
-
-    //viewer.showData('music', '<iframe style="overflow: hidden;" src="http://www.soundserum.com/" width="1200" height="1500"></iframe>', 'iframe');
     this.world = new World(this.url, this.url + 'buildindex.php');
     this.world.init(this.loaded);
   };
-
 }
-

--- a/world.js
+++ b/world.js
@@ -187,11 +187,14 @@ function addLine(p1, p2, chunk) {
 function parseChunk(data, pos) {
   if (data) {
     var dat = JSON.parse(data);
+    var c = Object();
+    c.pos = pos;
+    if(!dat || dat.length == 0) {
+      return c;
+    }
     var nbt = new NBTReader(dat);
     var ch = nbt.read();
     var blocks = ch.root.Level.Blocks;
-    var c = Object();
-    c.pos = pos;
     extractChunk(blocks, c);
     theworld.chunks.push(c);
     $('body').trigger({

--- a/world.js
+++ b/world.js
@@ -5,6 +5,7 @@
 //requires blockinfo
 
 var theworld;
+
 var ChunkSizeY = 128;
 var ChunkSizeZ = 16;
 var ChunkSizeX = 16;
@@ -16,43 +17,7 @@ var maxz = 4;
 var ymin = 5;
 var filled = [];
 
-function b36(n) {
-  var r = "";
-  
-  if (n == 0) 
-    r = '0';
-  else 
-    if (n < 0) 
-      r = '-' + baseConverter(Math.abs(n), 10, 36);
-    else 
-      r = baseConverter(n, 10, 36);
-  r = r.toLowerCase();
-  return r;
-}
-
-function posfolder(pos) {
-  var n = new Number(pos);
-  r = b36(n.mod(64));
-  return r;
-}
-
-function chunkfilename(x, z) {
-  return 'c.' + b36(x) + '.' + b36(z) + '.dat';
-}
-
-function chunkfile(x, z) {
-  return posfolder(x) + '/' + posfolder(z) + '/' + chunkfilename(x, z);
-/*
-  for (var i=0; i< theworld.chunkIndex.length; i++) {
-    var ch = theworld.chunkIndex[i];
-    var dat = ch.dat;
-    if (!dat) {
-      continue;
-    } else if (dat['xpos']==x && dat['zpos']==z) return ch.filename;
-  }
-  return 'unindexed';
-*/
-}
+var countChunks = 0;
 
 function transNeighbors(blocks, x, y, z) {
   for (i = x - 1; i < x + 2 & i < ChunkSizeX; i++) {
@@ -85,22 +50,15 @@ function extractChunk(blocks, chunk) {
          
         if (blockInfo[blockID]) {
           blockType = blockInfo[blockID];
-        }
-        else {
-        
+        } else {
           blockType = blockInfo['_-1'];
           log('unknown block type ' + blockID);
         }
         var show = false;
         
-        //if ((y>64) & blockType.id ===1) 
-        //  show = true;
-        
-    
         if (blockType.id !== 0) show = transNeighbors(blocks, x, y, z);
         
         if (show) {
-
           addBlock([x,y,z], chunk);
         }
         
@@ -110,7 +68,6 @@ function extractChunk(blocks, chunk) {
   countChunks++;
   renderChunk(chunk);
 }
-
 
 function addBlock(position, chunk) {
   var verts = [
@@ -149,14 +106,12 @@ function renderLines(chunk) {
   }
 }
 
-
 function renderPoints(chunk) {
   for (var i=0; i<chunk.filled.length; i++) {
     var verts = chunk.filled[i];
     renderVoxelPoints(chunk, verts[0], verts[1], verts[2]);
   }
 }
-
 
 function getBlockType(blocks, x, y, z) {
   var blockType = blockInfo['_-1'];
@@ -227,11 +182,9 @@ function addLine(p1, p2, chunk) {
   theworld.colors.push(c2[1]);
   theworld.colors.push(c2[2]);
   theworld.colors.push(c2[3]);
-
 }
 
-
-function parsechunk(data, pos) {
+function parseChunk(data, pos) {
   if (data) {
     var dat = JSON.parse(data);
     var nbt = new NBTReader(dat);
@@ -247,38 +200,21 @@ function parsechunk(data, pos) {
     });
     return c; 
   }
-/*
-  var blocks = tagfixed(data, 'Blocks', 32768);
-  var c = Object();
-  c.pos = pos;
-  extractChunk(blocks, c);
-  theworld.chunks.push(c);* /
-
-  return c; */
 }
 
-function chunkload(url, pos, callback) {
-  log('loading chunk pos=' + JSON.stringify(pos));
-  var fl = chunkfile(pos.x, pos.z);
-  if (fl != 'unindexed') {
-          var loc = url + 'getchunk.php?file=/' + 
-              encodeURIComponent(fl);
-          $.ajax({
-            url: loc,
-            dataType: 'html',
-            type: 'GET',
-            success: function(data) {
-              callback(theworld, parsechunk(data, pos));
-            },
-            error: function() {
-              callback(theworld, null);
-            }
-          });
-  } else {
-    callback(theworld, null);
-  }
+function chunkLoad(url, pos, callback) {
+  $.ajax({
+    url: url + 'getchunk.php?posx=' + pos.x + '&posz=' + pos.z,
+    dataType: 'html',
+    type: 'GET',
+    success: function(data) {
+      callback(theworld, parseChunk(data, pos));
+    },
+    error: function() {
+      callback(theworld, null);
+    }
+  });
 }
-
 
 function nextChunk(pos) {
   var next = new Object();
@@ -287,9 +223,7 @@ function nextChunk(pos) {
     next.x = pos.x + 1;
     next.z = pos.z;
     next.cont = true;
-  }
-  else {
-  
+  } else {
     if (pos.z < maxz) {
       next.z = pos.z + 1;
       next.x = minx;
@@ -299,19 +233,15 @@ function nextChunk(pos) {
   return next;
 }
 
-var countChunks = 0;
-
 function loadArea() {
   var w = this;
-  
-  chunkload(theworld.url, theworld.pos, function(chunk) {
-    var c = theworld.chunks[0];
+ 
+  chunkLoad(theworld.url, theworld.pos, function(chunk) {
     if (countChunks % 2 === 0) msg('loaded chunk at ' + theworld.pos.x + ', ' + theworld.pos.z);
     theworld.pos = nextChunk(theworld.pos);
     if (theworld.pos.cont) {
       theworld.loadArea();
-    }
-    else {
+    } else {
       status('loaded ' + countChunks + ' chunks &nbsp; &nbsp; &nbsp; LIKE A BOSS');
       $('#trace').animate({
         height: 'toggle'
@@ -320,7 +250,6 @@ function loadArea() {
     }
   });
 }
-
 
 function World(url, index) {
   this.url = url;
@@ -340,27 +269,27 @@ World.prototype.init = function(cb) {
   
   convertColors(); // in blockinfo.js
   w = this;
-  status("Loading..");
+  status("Loading...");
     
   $.get('getlevel.php', function(data) {
-     msg("Loaded level.dat");
-     var arr = JSON.parse(data);
-     var nbtreader = new NBTReader(arr);
-     var tmp = nbtreader.read();
-     w.level = tmp.root.Data;
-     msg('_______________');
-     msg('PlayerX = ' + w.level.Player.Pos[0]);
-     msg('PlayerZ = ' + w.level.Player.Pos[2]);
-     var posx = Math.round(w.level.Player.Pos[0] / ChunkSizeX);
-     var posz = Math.round(w.level.Player.Pos[2] / ChunkSizeZ);
-     msg('posx = ' + posx.toString());
-     msg('posz = ' + posz.toString()); 
-     $('#xmin').val(posx - 12);
-     $('#xmax').val(posx + 12);
-     $('#zmin').val(posz - 12);
-     $('#zmax').val(posz + 12);
-     w.chunks = [];
-     cb(theworld);
+    msg("Loaded level.dat");
+    var arr = JSON.parse(data);
+    var nbtreader = new NBTReader(arr);
+    var tmp = nbtreader.read();
+    w.level = tmp.root.Data;
+    msg('_______________');
+    msg('PlayerX = ' + w.level.Player.Pos[0]);
+    msg('PlayerZ = ' + w.level.Player.Pos[2]);
+    var posx = Math.round(w.level.Player.Pos[0] / ChunkSizeX);
+    var posz = Math.round(w.level.Player.Pos[2] / ChunkSizeZ);
+    msg('posx = ' + posx.toString());
+    msg('posz = ' + posz.toString()); 
+    $('#xmin').val(posx - 12);
+    $('#xmax').val(posx + 12);
+    $('#zmin').val(posz - 12);
+    $('#zmax').val(posz + 12);
+    w.chunks = [];
+    cb(theworld);
   });
 };
 


### PR DESCRIPTION
I'm not sure if anyone is still watching this repo but here's some stuff I've been hacking on. I was about to start a similar project from scratch so this definitely saved me a lot of time :)

readChunk (as it was renamed from readchunk) now reads chunks by position, rather than filename. The function calculates the region file of the chunk and reads just the part belonging to that chunk. (an initial attempt to dump entire regions proved unwise due to memory constraints).

jsonChunkOut passes an x and z position to readChunk and handles caching the generated json to disk.

jsonFileOut (same code as the old jsonchunkout) is now used only for the level.dat file.

I left buildindex.php alone (except for a quick reformat while I was trying to figure out what it was doing). I don't think it's needed so maybe it could be deleted?

I removed a few functions that dealt with the old chunk filenames since they were no longer needed. The javascript appreciates not having to calculate beyond a chunk position.

Regarding the style: I tried to pick the most prevalent formatting style and keep that consistent at least among the code I tweaked. This meant camelCasing, same-line braces, 2-space indentation, etc. I removed a few commented-out lines of code.
